### PR TITLE
move templates' initialization into the VoIDTemplate class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,11 +196,12 @@
     </plugins>
     <resources>
       <resource>
-          <directory>src/main/resources</directory>
-          <includes>
-              <include>*.xml</include>
-              <include>*.ttl</include>
-          </includes>
+        <directory>src/main/resources</directory>
+        <includes>
+          <include>*.xml</include>
+          <include>*.ttl</include>
+          <include>*.txt</include>
+        </includes>
       </resource>
     </resources>
     <testResources>

--- a/src/main/java/swiss/sib/swissprot/chistera/triples/VoIDTemplates.java
+++ b/src/main/java/swiss/sib/swissprot/chistera/triples/VoIDTemplates.java
@@ -1,0 +1,67 @@
+package swiss.sib.swissprot.chistera.triples;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+public final class VoIDTemplates {
+    
+        public static final String POM_TEMPLATE;
+
+        public static final String PREFIXES;
+        public static final String FIND_METHODS_FOR_CLASSES;
+        public static final String FIND_DATATYPE_PARTITIONS;
+        public static final String FIND_ALL_NAMED_GRAPHS;
+        public static final String FIND_PARTITION_TUPLE_QUERY;
+
+        static {
+                String pomTemplate = null;
+                try (InputStream is = VoIDTemplates.class.getResourceAsStream("/pom_template.xml")) {
+                        pomTemplate = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+                } catch (IOException ex) {
+                        ex.printStackTrace();
+                }
+                POM_TEMPLATE = pomTemplate;
+
+                String prefixes = null;
+                try (InputStream is = VoIDTemplates.class.getResourceAsStream("/prefixes.txt")) {
+                        prefixes = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+                } catch (IOException ex) {
+                        ex.printStackTrace();
+                }
+                PREFIXES = prefixes;
+
+                String find_methods_for_classes = PREFIXES;
+                try (InputStream is = VoIDTemplates.class.getResourceAsStream("/find_methods_for_classes.txt")) {
+                        find_methods_for_classes += new String(is.readAllBytes(), StandardCharsets.UTF_8);
+                } catch (IOException ex) {
+                        ex.printStackTrace();
+                }
+                FIND_METHODS_FOR_CLASSES = find_methods_for_classes;
+
+                String find_datatype_partitions = PREFIXES;
+                try (InputStream is = VoIDTemplates.class.getResourceAsStream("/find_datatype_partitions.txt")) {
+                        find_datatype_partitions += new String(is.readAllBytes(), StandardCharsets.UTF_8);
+                } catch (IOException ex) {
+                        ex.printStackTrace();
+                }
+                FIND_DATATYPE_PARTITIONS = find_datatype_partitions;
+
+                String find_all_named_graphs = PREFIXES;
+                try (InputStream is = VoIDTemplates.class.getResourceAsStream("/find_all_named_graphs.txt")) {
+                        find_all_named_graphs += new String(is.readAllBytes(), StandardCharsets.UTF_8);
+                } catch (IOException ex) {
+                        ex.printStackTrace();
+                }
+                FIND_ALL_NAMED_GRAPHS = find_all_named_graphs;
+                
+                String find_partition_tuple_query = PREFIXES;
+                try (InputStream is = VoIDTemplates.class.getResourceAsStream("/find_partition_tuple_query.txt")) {
+                        find_partition_tuple_query += new String(is.readAllBytes(), StandardCharsets.UTF_8);
+                } catch (IOException ex) {
+                        ex.printStackTrace();
+                }
+                FIND_PARTITION_TUPLE_QUERY = find_partition_tuple_query;
+
+        }
+}

--- a/src/main/resources/find_all_named_graphs.txt
+++ b/src/main/resources/find_all_named_graphs.txt
@@ -1,0 +1,5 @@
+SELECT ?namedGraph
+WHERE {
+	?dataset a sd:Dataset ;
+               sd:namedGraph ?namedGraph .
+}

--- a/src/main/resources/find_datatype_partitions.txt
+++ b/src/main/resources/find_datatype_partitions.txt
@@ -1,0 +1,9 @@
+SELECT *
+WHERE {
+  ?graph sd:graph/void:classPartition ?classPartition .
+  ?classPartition void:class ?classType .
+  ?classPartition void:propertyPartition ?predicatePartition .
+  ?predicatePartition void:property ?predicate .
+  ?predicatePartition void_ext:datatypePartition ?datatypePartition .
+  ?datatypePartition void_ext:datatype ?datatype .
+}

--- a/src/main/resources/find_methods_for_classes.txt
+++ b/src/main/resources/find_methods_for_classes.txt
@@ -1,0 +1,13 @@
+SELECT ?classPartition ?classType ?predicate ?class2Partition ?class2Type
+WHERE {
+  ?graph sd:graph/void:classPartition ?classPartition .
+  ?classPartition void:class ?classType .
+  ?classPartition void:propertyPartition ?predicatePartition .
+  ?predicatePartition void:property ?predicate .
+  ?class2Partition void:class ?class2Type .
+  [] a void:Linkset ;
+  	 void:objectsTarget ?class2Partition ;
+  	 void:linkPredicate ?predicate ;
+  	 void:subjectsTarget ?classPartition ;
+  	 void:subset ?graph .
+}

--- a/src/main/resources/find_partition_tuple_query.txt
+++ b/src/main/resources/find_partition_tuple_query.txt
@@ -1,0 +1,5 @@
+SELECT ?classPartition ?class
+WHERE {
+	?graph sd:graph/void:classPartition ?classPartition .
+	?classPartition void:class ?class .
+}

--- a/src/main/resources/prefixes.txt
+++ b/src/main/resources/prefixes.txt
@@ -1,0 +1,9 @@
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX pav: <http://purl.org/pav/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX void: <http://rdfs.org/ns/void#>
+PREFIX void_ext: <http://ldf.fi/void-ext#>
+PREFIX sd:<http://www.w3.org/ns/sparql-service-description#>


### PR DESCRIPTION
IMHO it would be more clean to have templates constants in the special configuration file.
I use *.txt extension for sparql templates. Probably it would be better to use *.sparql extension...

The code uses `try() {}` to ensure the resource stream is always closed. Note the readAllBytes() already closes the stream (unless we got an exception).

