### PR TITLE
docs: Add clarifications to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@ Many java programmers would like to just access the data without needing to unde
 This project is a code generator *in progress* that aims to use the given/descovered schema of data available in a SPARQL endpoint,
 and generate matching documented java code to access such data.
 
-# STATUS
+## STATUS
 
 Extremely early code. Still a lot to do, but one can test it out now as we have valid java code that runs the right kind of SPARQL queries.
 
-# GOAL
+## GOAL
 
 Imagine a small team, presenting a small open research dataset to the world. They might have some capabilities in their team to make 
 a website, a rest API in one language. But certainly not all the languages. The code in this repository shows how people could access
 this valuable data without learning SPARQL, in this case the people would be in the java community. However, the ideas here are an example
 for other ecosystems.
 
-# Use
+## USE
 
 First make the program (there are no releases yet)
 
@@ -27,3 +27,11 @@ cd VoIDToJava
 mvn package
 java -jar target/VoIDToJava.jar ${inputVoidFile} ${outputJavaCodeDirectory}
 ```
+
+The `${inputVoidFile}` can be generated e.g. with the [`void-generator`](https://github.com/JervenBolleman/void-generator).
+
+## BACKGROUND
+
+[See this presentation](https://docs.google.com/presentation/d/17w6wOagyE_bFuRr5zL5Ru66IBEmxeZBVKhSpZUQ0-qM/edit#slide=id.g337e9433fa7_0_34) for some related background,
+
+and http://www.w3.org/TR/void/ to learn more about the VoID Vocabulary which this project is based on.


### PR DESCRIPTION
@JervenBolleman 👋🏽 coming here from https://github.com/eclipse-rdf4j/rdf4j/issues/5284#issuecomment-2765301203,

while having a bit of a closer look at some of the options (now) listed on https://github.com/enola-dev/awesome-java-rdf#typed :

After an only ~3' look at the README and a 30s stare at the [README](https://github.com/TRIPLE-CHIST-ERA/VoIDToJava/blob/main/README.md) and the [GenerateJavaFromVoID](https://github.com/TRIPLE-CHIST-ERA/VoIDToJava/blob/main/src/main/java/swiss/sib/swissprot/chistera/triples/GenerateJavaFromVoID.java) class, at least I at first didn't "get" this project, yet...

... and after reading up a bit more I started understanding it a bit better. Perhaps these minor changes to the README could help other readers in the future?

PS: T'es à Lausanne, of all places in the world? 🇨‍🇭 Moi aussi! 🫕 Quelle hasard.